### PR TITLE
Create snt-university-of-luxembourg.md

### DIFF
--- a/universities/snt-university-of-luxembourg.md
+++ b/universities/snt-university-of-luxembourg.md
@@ -1,0 +1,22 @@
+# SnT, University of Luxembourg
+
+- *OSPO*: Yes, in the Technology Transfer Office
+- *Personnel*: Jacek Plucinski
+- *Link*: 
+- *Member of*: [CURIOSS](https://curioss.org/)
+
+## General Description
+
+
+
+## Core Objectives
+
+- 
+
+## Primary Contacts
+
+- [Jacek Plucinski](mailto:jacek.plucinski@uni.lu)
+
+## Other context
+
+More information [here](https://www.uni.lu/snt-fr/news/open-source-software-the-snt-way/).


### PR DESCRIPTION
@RichardLitt 

Created new profile for the University of Luxembourg.

NB. They've asked that we always include the SnT reference in the title.

@RichardLitt - reminder to link to: https://github.com/sustainers/academic-map/blob/main/universities.md