### PR TITLE
Corrected link to ETH Zurich in the index

### DIFF
--- a/universities/index.md
+++ b/universities/index.md
@@ -42,5 +42,5 @@ There's a host of universities which don't have open source program offices, but
 There are also universities that develop open source software, but don't have policies publicly set for staff or researchers.
 
 - University of Cambridge – [IT services has some code available](https://www.dns.cam.ac.uk/about/floss.html).
-- [ETH Zurich](./eth-zurich.md)
+- [ETH Zurich](https://sustainoss.org/academic-map/universities/eth-zurich.html)
 - [Rey Juan Carlos University](./rey-juan-carlos-university.md)


### PR DESCRIPTION
Hey there @RichardLitt @reginankenchor 

The link to ETH Zurich was in the Universities without OSPOs section but it didn't seem to be the correct link.  I've updated it with the link  to the ETH Zurich page in our map.

Can someone merge this please?