### PR TITLE
Support full CI/CD

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,0 +1,65 @@
+name: deploy-book
+
+# Run this when the master or main branch changes
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    # If your git repository has the Jupyter Book within some-subfolder next to
+    # unrelated files, you can make this run only if a file within that specific
+    # folder has been modified.
+    #
+    # paths:
+    # - some-subfolder/**
+
+# This job installs dependencies, builds the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - uses: actions/checkout@v3
+
+    # Install dependencies
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    # (optional) Cache your executed notebooks between runs
+    # if you have config:
+    # execute:
+    #   execute_notebooks: cache
+    - name: cache executed notebooks
+      uses: actions/cache@v3
+      with:
+        path: _build/.jupyter_cache
+        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
+
+    # Build the book
+    - name: Build the book
+      run: |
+        sh ./build.sh
+
+    # Upload the book's HTML as an artifact
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: "_build/html"
+
+    # Deploy the book's HTML to GitHub Pages
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,17 +1,11 @@
 name: deploy-book
 
-# Run this when the master or main branch changes
+# Runs on main branch changes or manual dispatch
 on:
   workflow_dispatch:
   push:
     branches:
     - main
-    # If your git repository has the Jupyter Book within some-subfolder next to
-    # unrelated files, you can make this run only if a file within that specific
-    # folder has been modified.
-    #
-    # paths:
-    # - some-subfolder/**
 
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
@@ -29,34 +23,9 @@ jobs:
       with:
         python-version: 3.11
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-
-    - name: Node install
-      run: |
-        npm install
-        npm install -g markdownlint-cli
-        markdownlint --help
-
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-
-    # (optional) Cache your executed notebooks between runs
-    # if you have config:
-    # execute:
-    #   execute_notebooks: cache
-    - name: cache executed notebooks
-      uses: actions/cache@v3
-      with:
-        path: _build/.jupyter_cache
-        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
-
-    - name: Lint
-      run: |
-        npm run run-all
 
     # Build the book
     - name: Build the book

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -15,7 +15,7 @@ on:
 
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
-  deploy-book:
+  build:
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -30,9 +30,15 @@ jobs:
         python-version: 3.11
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
+
+    - name: Node install
+      run: |
+        npm install
+        npm install -g markdownlint-cli
+        markdownlint --help
 
     - name: Install dependencies
       run: |
@@ -48,18 +54,33 @@ jobs:
         path: _build/.jupyter_cache
         key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
 
+    - name: Lint
+      run: |
+        npm run run-all
+
     # Build the book
     - name: Build the book
       run: |
-        sh ./build.sh
+        jupyter-book build --all .
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "_build/html"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    needs: build
+    steps:
 
     # Deploy the book's HTML to GitHub Pages
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,6 +1,6 @@
-name: Check Links
+name: Lint Markdown and check links
 on:
-  push:
+  pull_request:
     branches:
       - main
 
@@ -15,11 +15,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          # I had an issue here where the node-version needed to be above '14'
           node-version: '18'
 
       - name: Install Dependencies
-        run: npm install -g markdown-link-check
-
-      - name: Check Links
-        run: markdown-link-check -q ./*.md -c mdlinkcheckconfig.json && markdown-link-check ./**/*.md -q -c mdlinkcheckconfig.json
+        run: |
+          npm install
+          npm install -g markdownlint-cli
+          npm install -g markdown-link-check
+      - name: Lint markdown
+        run: npm run lint
+      - name: Link check
+        run: npm run links-ci

--- a/mdlinkcheckconfig.json
+++ b/mdlinkcheckconfig.json
@@ -25,6 +25,9 @@
       "pattern": "https://doi.org/10.7910/DVN/TJCLKP"
     },
     {
+      "pattern": "https://ospoplusplus.com"
+    },
+    {
       "pattern": "https://www.turing.ac.uk",
       "reason": "403"
     },
@@ -34,6 +37,10 @@
     },
     {
       "pattern": "https://www.aps.org/",
+      "reason": "403"
+    },
+    {
+      "pattern": "https://www.aaas.org/",
       "reason": "403"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,9 +950,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
-      "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,11 @@
   "description": "An ecosystem map for academic OSS",
   "scripts": {
     "build": "jupyter-book build --all .",
-
     "publish": "./build.sh",
-
     "lint": "markdownlint . -i _build/ -i node_modules",
     "lint-fix": "markdownlint --fix . -i _build/ -i node_modules",
     "links": "markdown-link-check ./*.md -c mdlinkcheckconfig.json && markdown-link-check ./**/*.md -c mdlinkcheckconfig.json",
     "links-ci": "markdown-link-check -q ./*.md -c mdlinkcheckconfig.json && markdown-link-check ./**/*.md -q -c mdlinkcheckconfig.json",
-
     "run-all": "npm run lint && npm run links-ci",
     "pretest": "npm run lint-fix"
   },


### PR DESCRIPTION
Resolves #149 

This PR updates our existing github actions workflow to do two things. 

 1. Automated build and deployment of the jupyter-book website to github pages (see note below)
 2. Updating our existing link-check workflow to also lint the markdown and be run on PRs.
 
 Hopefully with this PR, manually building/deploying the website should no longer be needed.

**Note:** for builds to work, the settings to this repo will need to be updated where the build and deployment source is changed to Github Actions as in the screenshot below.

![Screenshot From 2025-02-17 15-32-13](https://github.com/user-attachments/assets/4c2fdcae-5052-4dda-a09e-a9910b007c00)
