### PR TITLE
Update eth-zurich.md

### DIFF
--- a/mdlinkcheckconfig.json
+++ b/mdlinkcheckconfig.json
@@ -82,6 +82,18 @@
     {
       "pattern": "https://x.com/scicodes1",
       "reason": "400"
+    },
+    {
+      "pattern": "https://opsci.io",
+      "reason": "402"
+    },
+    {
+      "pattern": "https://commons.opsci.io/",
+      "reason": "402"
+    },
+    {
+      "pattern": "https://terminusdb.com/",
+      "reason": "0"
     }
   ]
 }

--- a/mdlinkcheckconfig.json
+++ b/mdlinkcheckconfig.json
@@ -98,6 +98,10 @@
     {
       "pattern": "https://www.heliosopen.org/members",
       "reason": "403"
+    },
+    {
+      "pattern": "https://you.stonybrook.edu/mckinnonrosati/open-source/",
+      "reason": "0"
     }
   ]
 }

--- a/organizations/index.md
+++ b/organizations/index.md
@@ -18,7 +18,7 @@ Sorted alphabetically.
 - [Linux Foundation](https://www.linuxfoundation.org/)
 - [Open Collective](https://opencollective.com)
   - [Open Source Collective](https://www.oscollective.org/)
-  - [Open Collective Foundation](https://opencollective.foundation/)
+  - [Open Collective Foundation](https://opencollective.com/foundation)
 - [Open Molecular Software Foundation](https://omsf.io/)
 - [NumFOCUS](https://numfocus.org)
 - **[Python Software Foundtion (PSF)](./psf.md)**

--- a/universities/eth-zurich.md
+++ b/universities/eth-zurich.md
@@ -1,13 +1,13 @@
 # ETH Zurich
 
-- *OSPO*: OSS Working Group, in the Tech Transfer Office
-- *Personnel*: Ying Wang
-- *Link*: [https://ethz.ch/en/industry/transfer.html](https://ethz.ch/en/industry/transfer.html)
+- *OSPO*: OSS Working Group, in the Tech Transfer Office  
+- *Personnel*: Ying Wang  
+- *Link*: [https://ethz.ch/en/industry/transfer.html](https://ethz.ch/en/industry/transfer.html)  
 - *Member of*: [CURIOSS](https://curioss.org/)
 
-## General Description
+## Open Source Program Office
 
-ETH Zurich has an OPSO that runs through the Tech Transfer Office (TTO). They have a long page explaining their [Open Source Policy](https://ethz.ch/en/industry/researchers/licensing-software/open-source-software.html), which includes information about licensing, patenting, and archiving their code.
+ETH Zurich has an OSPO that runs through the Tech Transfer Office (TTO). They have a long page explaining their [Open Source Policy](https://ethz.ch/en/industry/researchers/licensing-software/open-source-software.html), which includes information about licensing, patenting, and archiving their code.
 
 ## Core Objectives
 

--- a/universities/index.md
+++ b/universities/index.md
@@ -7,6 +7,7 @@ University involvement in open source varies widely. For instance, a university 
 The following universities have an office which has the standing of an Open Source Program Office:
 
 - [Carnegie Mellon University](./carnegie-mellon-university.md)
+- [ETH Zurich](./eth-zurich.md)
 - [George Washington University](./george-washington.md)
 - [Georgia Institute of Technology](./georgia-institute-of-technology.md)
 - [Johns Hopkins University](./johns-hopkins-university.md)
@@ -41,7 +42,6 @@ There's a host of universities which don't have open source program offices, but
 
 There are also universities that develop open source software, but don't have policies publicly set for staff or researchers.
 
-- [ETH Zurich](./eth-zurich.md)
 - [Rey Juan Carlos University](./rey-juan-carlos-university.md)
 - [Stony Brook University](./stony-brook-university.md)
 - [University at Buffalo](./university-at-buffalo.md)


### PR DESCRIPTION
This PR updates the ETH Zurich university page and its placement within the Academic Map to reflect the existence of its Open Source Program Office (OSPO).

Changes include:

    Added an Open Source Program Office section to eth-zurich.md, clarifying the role of the OSS Working Group under the Tech Transfer Office.

    Moved ETH Zurich from the “Universities without OSPOs” section to the “OSPOs” section in universities/index.md.

    Ensured that content and links reflect ETH Zurich’s open source engagement accurately.

This PR is connected to [Issue #151](https://github.com/sustainers/academic-map/issues/151).