### PR TITLE
Adding a link check for the build

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,4 +25,8 @@ jobs:
       - name: Lint markdown
         run: npm run lint
       - name: Link check
-        run: npm run links-ci
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: npm run links-ci


### PR DESCRIPTION
I could not replicate the 502 error locally. This should fix it.