### PR TITLE
Adding a TOC check on PRs

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -24,6 +24,8 @@ jobs:
           npm install -g markdown-link-check
       - name: Lint markdown
         run: npm run lint
+      - name: Check Table of Contents
+        run: npm run check-toc
       - name: Link check
         uses: nick-fields/retry@v3
         with:

--- a/_toc.yml
+++ b/_toc.yml
@@ -54,6 +54,8 @@ chapters:
     title: UPenn
   - file: universities/university-of-texas-austin.md
     title: UT Austin
+  - file: universities/university-of-texas-dallas.md
+    title: UT Dallas
   - file: universities/university-of-vermont.md
     title: UVM
   - file: universities/university-of-washington.md

--- a/universities/index.md
+++ b/universities/index.md
@@ -25,6 +25,7 @@ The following universities have an office which has the standing of an Open Sour
 - [University of California Santa Barbara](./university-of-california-santa-barbara.md)
 - [University of California Santa Cruz](./university-of-california-santa-cruz.md)
 - [University of Texas Austin](./university-of-texas-austin.md)
+- [University of Texas Dallas](./university-of-texas-dallas.md)
 - [University of Vermont](./university-of-vermont.md)
 - [University of Washington](./university-of-washington.md)
 - [University of Wisconsin-Madison](./university-of-wisconsin-madison.md)


### PR DESCRIPTION
Right now, the TOC isn't checked on PRs, but it stops this from being deployed. 